### PR TITLE
Add mutex to protect socketVector and set waittime to 100

### DIFF
--- a/mininode/tcpserver.h
+++ b/mininode/tcpserver.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <thread>
 #include <netdb.h>
+#include <mutex>
+
 
 class TCPServer {
 	friend class Socket;
@@ -31,6 +33,7 @@ private:
 	std::vector<Socket> socketVector;
 
 	static uint32_t activeCounter;
+	std::mutex vectMutex;
 };
 
 


### PR DESCRIPTION
Again, many thanks for releasing this code :-)

I found that when load testing the code, you would sometimes have the process crash as two threads were attempting to modify the socketVector object at the same time. I've added a mutex to try and protect it. I'm sure there might be a better way but it appears to work. 

I've also added a change so that waittime is not set to 0. I found that with this code:

```
std::min(waittime * 2, maxwaittime);
```

It meant that wait time would always be set to 0 causing the loop to never sleep and spin on the cpu. 

Apologies if these pull requests are unwelcome!
